### PR TITLE
Handle FluentFTP API updates and cancellation token binding

### DIFF
--- a/FtpMcpServer/Program.cs
+++ b/FtpMcpServer/Program.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using FtpMcpServer;
 using FtpMcpServer.Auth;
 using FtpMcpServer.Resources;
@@ -59,6 +60,7 @@ builder.Services
     {
         // The server tracks the current logging level internally; returning an EmptyResult is sufficient.
         // If you want to actually change Microsoft.Extensions.Logging levels dynamically, you can wire that up here.
+        await Task.CompletedTask.ConfigureAwait(false);
         return new EmptyResult();
     });
 

--- a/FtpMcpServer/Resources/FluentFtpResourceType.cs
+++ b/FtpMcpServer/Resources/FluentFtpResourceType.cs
@@ -19,14 +19,15 @@ namespace FtpMcpServer.Resources
         public static async Task<ResourceContents> Read(
             RequestContext<ReadResourceRequestParams> requestContext,
             FtpDefaults defaults,
-            [Description("Remote path to the file (URL-encoded if it includes slashes)")] string? path = null)
+            [Description("Remote path to the file (URL-encoded if it includes slashes)")] string? path = null,
+            CancellationToken cancellationToken = default)
         {
             // Resolve the remote path using the optional path and the defaults (falls back to defaults.DefaultPath when null).
             var remotePath = FtpPathHelper.ResolvePath(defaults, path);
 
             byte[] bytes = await Task.Run(
                 () => FluentFtpService.DownloadBytes(defaults, remotePath),
-                requestContext.CancellationToken).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
 
             string b64 = Convert.ToBase64String(bytes);
             string mime = MimeHelper.GetMimeType(remotePath);

--- a/FtpMcpServer/Tools/FtpTools.cs
+++ b/FtpMcpServer/Tools/FtpTools.cs
@@ -38,7 +38,7 @@ namespace FtpMcpServer.Tools
                     Size = it.Size >= 0 ? it.Size : null,
                     Modified = it.Modified == DateTime.MinValue ? null : it.Modified,
                     Permissions = it.RawPermissions,
-                    Raw = it.RawListing
+                    Raw = it.Input
                 });
             }
 


### PR DESCRIPTION
## Summary
- update FTP listing tool to use the current FluentFTP item input string
- accept a cancellation token when reading resources and pass it through to background work
- await a completed task in the logging level handler to eliminate build warnings

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68f4a2398aa883248f2b7ff7e61d56d3