### PR TITLE
Add structured logging across FTP MCP server

### DIFF
--- a/FtpMcpServer/Program.cs
+++ b/FtpMcpServer/Program.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using FtpMcpServer;
 using FtpMcpServer.Auth;
 using FtpMcpServer.Resources;
+using FtpMcpServer.Services;
 using FtpMcpServer.Tools;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
@@ -39,6 +40,10 @@ builder.Services.AddScoped<FtpDefaults>(sp =>
     var user = http?.User;
     return FtpDefaults.FromClaims(user);
 });
+
+// FTP service and tool dependencies
+builder.Services.AddSingleton<IFluentFtpService, FluentFtpService>();
+builder.Services.AddSingleton<FtpTools>();
 
 // MCP server configuration (HTTP URL transport)
 builder.Services

--- a/FtpMcpServer/Services/FluentFtpService.cs
+++ b/FtpMcpServer/Services/FluentFtpService.cs
@@ -2,82 +2,152 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using FluentFTP;
+using Microsoft.Extensions.Logging;
 
 namespace FtpMcpServer.Services
 {
-    internal static class FluentFtpService
+    internal sealed class FluentFtpService : IFluentFtpService
     {
-        public static IReadOnlyList<FtpListItem> GetListing(FtpDefaults defaults, string path)
+        private readonly ILogger<FluentFtpService> _logger;
+
+        public FluentFtpService(ILogger<FluentFtpService> logger)
         {
-            using var client = CreateAndConnect(defaults);
-            return client.GetListing(path, FtpListOption.Modify | FtpListOption.Size);
+            _logger = logger;
         }
 
-        public static byte[] DownloadBytes(FtpDefaults defaults, string path)
+        public IReadOnlyList<FtpListItem> GetListing(FtpDefaults defaults, string path)
         {
-            using var client = CreateAndConnect(defaults);
-            if (!client.DownloadBytes(out var bytes, path))
+            return Execute(defaults, path, client =>
             {
-                throw new InvalidOperationException($"Failed to download '{path}' from FTP server.");
-            }
-
-            return bytes ?? Array.Empty<byte>();
+                _logger.LogInformation("Listing FTP directory {Path} on {Host}:{Port}.", path, defaults.Host, defaults.Port);
+                var listing = client.GetListing(path, FtpListOption.Modify | FtpListOption.Size);
+                _logger.LogInformation("Found {Count} items while listing {Path} on {Host}:{Port}.", listing.Length, defaults.Host, defaults.Port);
+                return listing;
+            });
         }
 
-        public static void UploadBytes(FtpDefaults defaults, string path, byte[] data)
+        public byte[] DownloadBytes(FtpDefaults defaults, string path)
         {
-            using var client = CreateAndConnect(defaults);
-            var status = client.UploadBytes(data, path, FtpRemoteExists.Overwrite, createRemoteDir: true);
-            if (status == FtpStatus.Failed)
+            return Execute(defaults, path, client =>
             {
-                throw new InvalidOperationException($"Failed to upload '{path}' to FTP server.");
+                _logger.LogInformation("Downloading FTP file {Path} from {Host}:{Port}.", path, defaults.Host, defaults.Port);
+                if (!client.DownloadBytes(out var bytes, path))
+                {
+                    throw new InvalidOperationException($"Failed to download '{path}' from FTP server.");
+                }
+
+                var length = bytes?.Length ?? 0;
+                _logger.LogInformation("Downloaded {Length} bytes from {Path} on {Host}:{Port}.", length, path, defaults.Host, defaults.Port);
+                return bytes ?? Array.Empty<byte>();
+            });
+        }
+
+        public void UploadBytes(FtpDefaults defaults, string path, byte[] data)
+        {
+            Execute(defaults, path, client =>
+            {
+                _logger.LogInformation("Uploading {Length} bytes to FTP path {Path} on {Host}:{Port}.", data.Length, path, defaults.Host, defaults.Port);
+                var status = client.UploadBytes(data, path, FtpRemoteExists.Overwrite, createRemoteDir: true);
+                if (status == FtpStatus.Failed)
+                {
+                    throw new InvalidOperationException($"Failed to upload '{path}' to FTP server.");
+                }
+
+                _logger.LogInformation("Successfully uploaded data to {Path} on {Host}:{Port}.", path, defaults.Host, defaults.Port);
+                return true;
+            });
+        }
+
+        public void DeleteFile(FtpDefaults defaults, string path)
+        {
+            Execute(defaults, path, client =>
+            {
+                _logger.LogInformation("Deleting FTP file {Path} on {Host}:{Port}.", path, defaults.Host, defaults.Port);
+                client.DeleteFile(path);
+                _logger.LogInformation("Deleted FTP file {Path} on {Host}:{Port}.", path, defaults.Host, defaults.Port);
+                return true;
+            });
+        }
+
+        public void CreateDirectory(FtpDefaults defaults, string path)
+        {
+            Execute(defaults, path, client =>
+            {
+                _logger.LogInformation("Creating FTP directory {Path} on {Host}:{Port}.", path, defaults.Host, defaults.Port);
+                client.CreateDirectory(path, force: true);
+                _logger.LogInformation("Created FTP directory {Path} on {Host}:{Port}.", path, defaults.Host, defaults.Port);
+                return true;
+            });
+        }
+
+        public void DeleteDirectory(FtpDefaults defaults, string path)
+        {
+            Execute(defaults, path, client =>
+            {
+                _logger.LogInformation("Deleting FTP directory {Path} on {Host}:{Port}.", path, defaults.Host, defaults.Port);
+                client.DeleteDirectory(path);
+                _logger.LogInformation("Deleted FTP directory {Path} on {Host}:{Port}.", path, defaults.Host, defaults.Port);
+                return true;
+            });
+        }
+
+        public void Rename(FtpDefaults defaults, string sourcePath, string destinationPath)
+        {
+            Execute(defaults, sourcePath, client =>
+            {
+                _logger.LogInformation("Renaming FTP path {SourcePath} to {DestinationPath} on {Host}:{Port}.", sourcePath, destinationPath, defaults.Host, defaults.Port);
+                client.Rename(sourcePath, destinationPath);
+                _logger.LogInformation("Renamed FTP path {SourcePath} to {DestinationPath} on {Host}:{Port}.", sourcePath, destinationPath, defaults.Host, defaults.Port);
+                return true;
+            });
+        }
+
+        public long GetFileSize(FtpDefaults defaults, string path)
+        {
+            return Execute(defaults, path, client =>
+            {
+                _logger.LogInformation("Retrieving size for FTP file {Path} on {Host}:{Port}.", path, defaults.Host, defaults.Port);
+                var size = client.GetFileSize(path);
+                _logger.LogInformation("FTP file {Path} on {Host}:{Port} is {Size} bytes.", path, defaults.Host, defaults.Port, size);
+                return size;
+            });
+        }
+
+        public DateTime GetModifiedTime(FtpDefaults defaults, string path)
+        {
+            return Execute(defaults, path, client =>
+            {
+                _logger.LogInformation("Retrieving modified time for FTP file {Path} on {Host}:{Port}.", path, defaults.Host, defaults.Port);
+                var modified = client.GetModifiedTime(path);
+                _logger.LogInformation("FTP file {Path} on {Host}:{Port} was last modified at {Modified}.", path, defaults.Host, defaults.Port, modified);
+                return modified;
+            });
+        }
+
+        private T Execute<T>(FtpDefaults defaults, string path, Func<FtpClient, T> action)
+        {
+            try
+            {
+                using var client = CreateAndConnect(defaults);
+                return action(client);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "FTP operation failed for path {Path} on {Host}:{Port}.", path, defaults.Host, defaults.Port);
+                throw;
             }
         }
 
-        public static void DeleteFile(FtpDefaults defaults, string path)
-        {
-            using var client = CreateAndConnect(defaults);
-            client.DeleteFile(path);
-        }
-
-        public static void CreateDirectory(FtpDefaults defaults, string path)
-        {
-            using var client = CreateAndConnect(defaults);
-            client.CreateDirectory(path, force: true);
-        }
-
-        public static void DeleteDirectory(FtpDefaults defaults, string path)
-        {
-            using var client = CreateAndConnect(defaults);
-            client.DeleteDirectory(path);
-        }
-
-        public static void Rename(FtpDefaults defaults, string sourcePath, string destinationPath)
-        {
-            using var client = CreateAndConnect(defaults);
-            client.Rename(sourcePath, destinationPath);
-        }
-
-        public static long GetFileSize(FtpDefaults defaults, string path)
-        {
-            using var client = CreateAndConnect(defaults);
-            return client.GetFileSize(path);
-        }
-
-        public static DateTime GetModifiedTime(FtpDefaults defaults, string path)
-        {
-            using var client = CreateAndConnect(defaults);
-            return client.GetModifiedTime(path);
-        }
-
-        private static FtpClient CreateAndConnect(FtpDefaults defaults)
+        private FtpClient CreateAndConnect(FtpDefaults defaults)
         {
             var client = CreateClient(defaults);
+            _logger.LogDebug("Connecting to FTP server {Host}:{Port} (SSL: {UseSsl}, Passive: {Passive}).", defaults.Host, defaults.Port, defaults.UseSsl, defaults.Passive);
             client.Connect();
+            _logger.LogDebug("Connected to FTP server {Host}:{Port}.", defaults.Host, defaults.Port);
             return client;
         }
 
-        private static FtpClient CreateClient(FtpDefaults defaults)
+        private FtpClient CreateClient(FtpDefaults defaults)
         {
             if (string.IsNullOrWhiteSpace(defaults.Host))
             {

--- a/FtpMcpServer/Services/IFluentFtpService.cs
+++ b/FtpMcpServer/Services/IFluentFtpService.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using FluentFTP;
+
+namespace FtpMcpServer.Services
+{
+    internal interface IFluentFtpService
+    {
+        IReadOnlyList<FtpListItem> GetListing(FtpDefaults defaults, string path);
+
+        byte[] DownloadBytes(FtpDefaults defaults, string path);
+
+        void UploadBytes(FtpDefaults defaults, string path, byte[] data);
+
+        void DeleteFile(FtpDefaults defaults, string path);
+
+        void CreateDirectory(FtpDefaults defaults, string path);
+
+        void DeleteDirectory(FtpDefaults defaults, string path);
+
+        void Rename(FtpDefaults defaults, string sourcePath, string destinationPath);
+
+        long GetFileSize(FtpDefaults defaults, string path);
+
+        DateTime GetModifiedTime(FtpDefaults defaults, string path);
+    }
+}

--- a/FtpMcpServer/Tools/FtpTools.cs
+++ b/FtpMcpServer/Tools/FtpTools.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
 using FtpMcpServer.Services;
+using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
@@ -11,14 +12,24 @@ namespace FtpMcpServer.Tools
     [McpServerToolType]
     public class FtpTools
     {
+        private readonly ILogger<FtpTools> _logger;
+        private readonly IFluentFtpService _ftpService;
+
+        public FtpTools(ILogger<FtpTools> logger, IFluentFtpService ftpService)
+        {
+            _logger = logger;
+            _ftpService = ftpService;
+        }
+
         [McpServerTool(Name = "ftp_listDirectory", UseStructuredContent = true, ReadOnly = true, OpenWorld = true, Idempotent = true)]
         [Description("Lists entries in an FTP directory. Returns structured JSON describing each item.")]
-        public static FtpListResult ListDirectory(
+        public FtpListResult ListDirectory(
             FtpDefaults defaults,
             [Description("Remote path to list (e.g., /pub). Defaults to the server default path or '/'")] string? path = null)
         {
             var remotePath = FtpPathHelper.ResolvePath(defaults, path);
-            var items = FluentFtpService.GetListing(defaults, remotePath);
+            _logger.LogInformation("Listing directory {Path} on FTP host {Host}:{Port}.", remotePath, defaults.Host, defaults.Port);
+            var items = _ftpService.GetListing(defaults, remotePath);
             var result = new FtpListResult
             {
                 Host = FtpPathHelper.GetHostOrThrow(defaults),
@@ -42,21 +53,24 @@ namespace FtpMcpServer.Tools
                 });
             }
 
+            _logger.LogInformation("Returning {Count} FTP items for directory {Path} on {Host}:{Port}.", result.Items.Count, remotePath, defaults.Host, defaults.Port);
             return result;
         }
 
         [McpServerTool(Name = "ftp_downloadFile", ReadOnly = true, OpenWorld = true, Idempotent = true)]
         [Description("Downloads an FTP file and returns it as an embedded MCP resource (base64-encoded).")]
-        public static ContentBlock DownloadFile(
+        public ContentBlock DownloadFile(
             FtpDefaults defaults,
             [Description("Remote file path to download (e.g., /pub/file.txt)")] string path)
         {
             var remotePath = FtpPathHelper.ResolvePath(defaults, path);
-            var bytes = FluentFtpService.DownloadBytes(defaults, remotePath);
+            _logger.LogInformation("Downloading FTP file {Path} from {Host}:{Port}.", remotePath, defaults.Host, defaults.Port);
+            var bytes = _ftpService.DownloadBytes(defaults, remotePath);
             string b64 = Convert.ToBase64String(bytes);
             string uri = FtpPathHelper.BuildUri(defaults, remotePath).ToString();
             string mime = MimeHelper.GetMimeType(remotePath);
 
+            _logger.LogInformation("Downloaded {Length} bytes from {Path} on {Host}:{Port}.", bytes.Length, remotePath, defaults.Host, defaults.Port);
             return new EmbeddedResourceBlock
             {
                 Resource = new BlobResourceContents
@@ -70,20 +84,21 @@ namespace FtpMcpServer.Tools
 
         [McpServerTool(Name = "ftp_uploadFile", Destructive = true, OpenWorld = true, Idempotent = true)]
         [Description("Uploads data as a file to the FTP server. Data is expected to be base64-encoded.")]
-        public static string UploadFile(
+        public string UploadFile(
             FtpDefaults defaults,
             [Description("Remote file path to upload to (e.g., /incoming/file.txt)")] string path,
             [Description("Base64-encoded file content to upload")] string dataBase64)
         {
             var bytes = Convert.FromBase64String(dataBase64);
             var remotePath = FtpPathHelper.ResolvePath(defaults, path);
-            FluentFtpService.UploadBytes(defaults, remotePath, bytes);
+            _logger.LogInformation("Uploading {Length} bytes to FTP path {Path} on {Host}:{Port}.", bytes.Length, remotePath, defaults.Host, defaults.Port);
+            _ftpService.UploadBytes(defaults, remotePath, bytes);
             return $"Uploaded {bytes.Length} bytes to {FtpPathHelper.BuildUri(defaults, remotePath)}";
         }
 
         [McpServerTool(Name = "ftp_writeFile", Destructive = true, OpenWorld = true, Idempotent = true)]
         [Description("Writes plain text content to a file on the FTP server using the specified encoding (UTF-8 by default).")]
-        public static string WriteFile(
+        public string WriteFile(
             FtpDefaults defaults,
             [Description("Remote file path to write to (e.g., /incoming/file.txt)")] string path,
             [Description("Plain text content to write to the file")] string content,
@@ -101,74 +116,81 @@ namespace FtpMcpServer.Tools
 
             var bytes = enc.GetBytes(content ?? string.Empty);
             var remotePath = FtpPathHelper.ResolvePath(defaults, path);
-            FluentFtpService.UploadBytes(defaults, remotePath, bytes);
+            _logger.LogInformation("Writing {Length} bytes (encoding: {Encoding}) to FTP path {Path} on {Host}:{Port}.", bytes.Length, enc.WebName, remotePath, defaults.Host, defaults.Port);
+            _ftpService.UploadBytes(defaults, remotePath, bytes);
             return $"Wrote {bytes.Length} bytes to {FtpPathHelper.BuildUri(defaults, remotePath)} using {enc.WebName} encoding";
         }
 
         [McpServerTool(Name = "ftp_deleteFile", Destructive = true, OpenWorld = true, Idempotent = true)]
         [Description("Deletes a file on the FTP server.")]
-        public static string DeleteFile(
+        public string DeleteFile(
             FtpDefaults defaults,
             [Description("Remote file path to delete (e.g., /pub/file.txt)")] string path)
         {
             var remotePath = FtpPathHelper.ResolvePath(defaults, path);
-            FluentFtpService.DeleteFile(defaults, remotePath);
+            _logger.LogInformation("Deleting FTP file {Path} on {Host}:{Port}.", remotePath, defaults.Host, defaults.Port);
+            _ftpService.DeleteFile(defaults, remotePath);
             return $"Deleted {FtpPathHelper.BuildUri(defaults, remotePath)}";
         }
 
         [McpServerTool(Name = "ftp_makeDirectory", Destructive = true, OpenWorld = true, Idempotent = true)]
         [Description("Creates a directory on the FTP server.")]
-        public static string MakeDirectory(
+        public string MakeDirectory(
             FtpDefaults defaults,
             [Description("Remote directory path to create (e.g., /pub/newdir)")] string path)
         {
             var remotePath = FtpPathHelper.ResolvePath(defaults, path);
-            FluentFtpService.CreateDirectory(defaults, remotePath);
+            _logger.LogInformation("Creating FTP directory {Path} on {Host}:{Port}.", remotePath, defaults.Host, defaults.Port);
+            _ftpService.CreateDirectory(defaults, remotePath);
             return $"Created directory {FtpPathHelper.BuildUri(defaults, remotePath)}";
         }
 
         [McpServerTool(Name = "ftp_removeDirectory", Destructive = true, OpenWorld = true, Idempotent = true)]
         [Description("Removes a directory on the FTP server (must be empty).")]
-        public static string RemoveDirectory(
+        public string RemoveDirectory(
             FtpDefaults defaults,
             [Description("Remote directory path to remove (must be empty)")] string path)
         {
             var remotePath = FtpPathHelper.ResolvePath(defaults, path);
-            FluentFtpService.DeleteDirectory(defaults, remotePath);
+            _logger.LogInformation("Removing FTP directory {Path} on {Host}:{Port}.", remotePath, defaults.Host, defaults.Port);
+            _ftpService.DeleteDirectory(defaults, remotePath);
             return $"Removed directory {FtpPathHelper.BuildUri(defaults, remotePath)}";
         }
 
         [McpServerTool(Name = "ftp_rename", Destructive = true, OpenWorld = true, Idempotent = true)]
         [Description("Renames a file or directory on the FTP server.")]
-        public static string Rename(
+        public string Rename(
             FtpDefaults defaults,
             [Description("Current remote path to rename")] string path,
             [Description("New name (not a full path)")] string newName)
         {
             var remotePath = FtpPathHelper.ResolvePath(defaults, path);
             var destinationPath = FtpPathHelper.CombineDirectoryAndName(remotePath, newName);
-            FluentFtpService.Rename(defaults, remotePath, destinationPath);
+            _logger.LogInformation("Renaming FTP path {Path} to {Destination} on {Host}:{Port}.", remotePath, destinationPath, defaults.Host, defaults.Port);
+            _ftpService.Rename(defaults, remotePath, destinationPath);
             return $"Renamed {FtpPathHelper.BuildUri(defaults, remotePath)} to {newName}";
         }
 
         [McpServerTool(Name = "ftp_getFileSize", ReadOnly = true, OpenWorld = true, Idempotent = true)]
         [Description("Gets the size (in bytes) of a remote file.")]
-        public static long GetFileSize(
+        public long GetFileSize(
             FtpDefaults defaults,
             [Description("Remote file path")] string path)
         {
             var remotePath = FtpPathHelper.ResolvePath(defaults, path);
-            return FluentFtpService.GetFileSize(defaults, remotePath);
+            _logger.LogInformation("Retrieving file size for FTP path {Path} on {Host}:{Port}.", remotePath, defaults.Host, defaults.Port);
+            return _ftpService.GetFileSize(defaults, remotePath);
         }
 
         [McpServerTool(Name = "ftp_getModifiedTime", ReadOnly = true, OpenWorld = true, Idempotent = true)]
         [Description("Gets the last modified time (server local time) of a remote file.")]
-        public static DateTime GetModifiedTime(
+        public DateTime GetModifiedTime(
             FtpDefaults defaults,
             [Description("Remote file path")] string path)
         {
             var remotePath = FtpPathHelper.ResolvePath(defaults, path);
-            return FluentFtpService.GetModifiedTime(defaults, remotePath);
+            _logger.LogInformation("Retrieving modified time for FTP path {Path} on {Host}:{Port}.", remotePath, defaults.Host, defaults.Port);
+            return _ftpService.GetModifiedTime(defaults, remotePath);
         }
     }
 


### PR DESCRIPTION
## Summary
- convert the FTP helper service into a logger-aware dependency and register it for DI
- add detailed logging to each FTP tool operation for better observability

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f4a6f0ed088324ad5007bce7cd9bb1