### PR TITLE
Make FluentFtpService public

### DIFF
--- a/FtpMcpServer/Services/FluentFtpService.cs
+++ b/FtpMcpServer/Services/FluentFtpService.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace FtpMcpServer.Services
 {
-    internal sealed class FluentFtpService : IFluentFtpService
+    public sealed class FluentFtpService : IFluentFtpService
     {
         private readonly ILogger<FluentFtpService> _logger;
 

--- a/FtpMcpServer/Services/IFluentFtpService.cs
+++ b/FtpMcpServer/Services/IFluentFtpService.cs
@@ -4,7 +4,7 @@ using FluentFTP;
 
 namespace FtpMcpServer.Services
 {
-    internal interface IFluentFtpService
+    public interface IFluentFtpService
     {
         IReadOnlyList<FtpListItem> GetListing(FtpDefaults defaults, string path);
 


### PR DESCRIPTION
## Summary
- expose `IFluentFtpService` as a public interface
- make `FluentFtpService` a public sealed class to match the interface visibility

## Testing
- dotnet build FtpMcpServer.sln *(fails: `dotnet` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f7173c48548324adebc8a9d9838835