### PR TITLE
Use content type provider for FTP downloads

### DIFF
--- a/FtpMcpServer/Tools/FtpTools.cs
+++ b/FtpMcpServer/Tools/FtpTools.cs
@@ -72,7 +72,9 @@ namespace FtpMcpServer.Tools
             var bytes = _ftpService.DownloadBytes(defaults, remotePath);
             string b64 = Convert.ToBase64String(bytes);
             string uri = BuildUri(defaults, remotePath).ToString();
-            string mime = MimeHelper.GetMimeType(remotePath);
+            string mime = _contentTypeProvider.TryGetContentType(remotePath, out var contentType)
+                ? contentType
+                : "application/octet-stream";
 
             _logger.LogInformation("Downloaded {Length} bytes from {Path} on {Host}:{Port}.", bytes.Length, remotePath, defaults.Host, defaults.Port);
             return new EmbeddedResourceBlock


### PR DESCRIPTION
## Summary
- use the injected content type provider when determining the MIME type for downloaded FTP files
- fall back to application/octet-stream to stay consistent with the resource implementation

## Testing
- dotnet build *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f7174995cc8324b3e56e12a3a82781