### PR TITLE
Fix FTP resource dependency injection and logging template

### DIFF
--- a/FtpMcpServer/Resources/FluentFtpResourceType.cs
+++ b/FtpMcpServer/Resources/FluentFtpResourceType.cs
@@ -21,6 +21,7 @@ namespace FtpMcpServer.Resources
         public static async Task<ResourceContents> Read(
             RequestContext<ReadResourceRequestParams> requestContext,
             FtpDefaults defaults,
+            IFluentFtpService ftpService,
             FileExtensionContentTypeProvider contentTypeProvider,
             [Description("Remote path to the file (URL-encoded if it includes slashes)")] string? path = null,
             CancellationToken cancellationToken = default)
@@ -29,7 +30,7 @@ namespace FtpMcpServer.Resources
             var remotePath = GetRemotePath(defaults, path);
 
             byte[] bytes = await Task.Run(
-                () => FluentFtpService.DownloadBytes(defaults, remotePath),
+                () => ftpService.DownloadBytes(defaults, remotePath),
                 cancellationToken).ConfigureAwait(false);
 
             string b64 = Convert.ToBase64String(bytes);

--- a/FtpMcpServer/Services/FluentFtpService.cs
+++ b/FtpMcpServer/Services/FluentFtpService.cs
@@ -21,7 +21,12 @@ namespace FtpMcpServer.Services
             {
                 _logger.LogInformation("Listing FTP directory {Path} on {Host}:{Port}.", path, defaults.Host, defaults.Port);
                 var listing = client.GetListing(path, FtpListOption.Modify | FtpListOption.Size);
-                _logger.LogInformation("Found {Count} items while listing {Path} on {Host}:{Port}.", listing.Length, defaults.Host, defaults.Port);
+                _logger.LogInformation(
+                    "Found {Count} items while listing {Path} on {Host}:{Port}.",
+                    listing.Length,
+                    path,
+                    defaults.Host,
+                    defaults.Port);
                 return listing;
             });
         }


### PR DESCRIPTION
## Summary
- inject the fluent FTP service into the resource reader so it uses the registered dependency
- fix the directory listing log message to supply all placeholders

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f7181b77c083248926d78710810f1c