### PR TITLE
Enable structured FTP download responses

### DIFF
--- a/FtpMcpServer/Tools/FtpTools.cs
+++ b/FtpMcpServer/Tools/FtpTools.cs
@@ -61,9 +61,9 @@ namespace FtpMcpServer.Tools
             return result;
         }
 
-        [McpServerTool(Name = "ftp_downloadFile", ReadOnly = true, OpenWorld = true, Idempotent = true)]
+        [McpServerTool(Name = "ftp_downloadFile", UseStructuredContent = true, ReadOnly = true, OpenWorld = true, Idempotent = true)]
         [Description("Downloads an FTP file and returns it as an embedded MCP resource (base64-encoded).")]
-        public ContentBlock DownloadFile(
+        public IReadOnlyList<ContentBlock> DownloadFile(
             FtpDefaults defaults,
             [Description("Remote file path to download (e.g., /pub/file.txt)")] string path)
         {
@@ -77,13 +77,16 @@ namespace FtpMcpServer.Tools
                 : "application/octet-stream";
 
             _logger.LogInformation("Downloaded {Length} bytes from {Path} on {Host}:{Port}.", bytes.Length, remotePath, defaults.Host, defaults.Port);
-            return new EmbeddedResourceBlock
+            return new List<ContentBlock>
             {
-                Resource = new BlobResourceContents
+                new EmbeddedResourceBlock
                 {
-                    Uri = uri,
-                    MimeType = mime,
-                    Blob = b64
+                    Resource = new BlobResourceContents
+                    {
+                        Uri = uri,
+                        MimeType = mime,
+                        Blob = b64
+                    }
                 }
             };
         }


### PR DESCRIPTION
## Summary
- set the `ftp_downloadFile` tool to advertise structured content so MCP clients handle `ContentBlock` responses
- return the embedded resource inside a list of content blocks to emit structured content explicitly

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68f71ed9ece88324bac9e5c59887f22d