### PR TITLE
Use FluentFTP helpers for rename target resolution

### DIFF
--- a/FtpMcpServer/Tools/FtpTools.cs
+++ b/FtpMcpServer/Tools/FtpTools.cs
@@ -171,7 +171,13 @@ namespace FtpMcpServer.Tools
             [Description("New name (not a full path)")] string newName)
         {
             var remotePath = GetRemotePath(defaults, path);
-            var destinationPath = RemotePaths.GetFtpPath(remotePath, newName);
+            var parentDirectory = remotePath.GetFtpDirectoryName();
+            if (string.IsNullOrEmpty(parentDirectory) || parentDirectory == ".")
+            {
+                parentDirectory = "/";
+            }
+
+            var destinationPath = parentDirectory.GetFtpPath(newName);
             _logger.LogInformation("Renaming FTP path {Path} to {Destination} on {Host}:{Port}.", remotePath, destinationPath, defaults.Host, defaults.Port);
             _ftpService.Rename(defaults, remotePath, destinationPath);
             return $"Renamed {BuildUri(defaults, remotePath)} to {newName}";


### PR DESCRIPTION
## Summary
- derive the destination folder for renames with RemotePaths.GetFtpDirectoryName so both files and directories resolve correctly
- construct the final destination using RemotePaths.GetFtpPath to keep path handling within FluentFTP helpers

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f71eb6737883248b157aac1ee643b5