### PR TITLE
Add textual confirmation to FTP download response

### DIFF
--- a/FtpMcpServer/Tools/FtpTools.cs
+++ b/FtpMcpServer/Tools/FtpTools.cs
@@ -104,6 +104,7 @@ namespace FtpMcpServer.Tools
             // Return both: embedded resource and a link (best of both worlds for all clients)
             var content = new List<ContentBlock>
             {
+                new TextContentBlock { Text = $"Downloaded {name} ({size} bytes)." },
                 new EmbeddedResourceBlock
                 {
                     Resource = new BlobResourceContents


### PR DESCRIPTION
## Summary
- add a `TextContentBlock` to the FTP download response content to provide a human-readable summary alongside the embedded resource and resource link

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7da876f148324997063c4baf4cee5